### PR TITLE
Changed name of "OKC Raspberry Pi" group to "OKC Open Source Hardware"

### DIFF
--- a/OKC-Open-Source-Hardware/README.md
+++ b/OKC-Open-Source-Hardware/README.md
@@ -1,10 +1,10 @@
-**Group email:** 
+**Group email:**
 
-Other Code of Conduct(s): N/A 
+Other Code of Conduct(s): N/A
 
 #### Urls:
-  - Event hub: [Meetup](https://www.meetup.com/OKC-Raspberry-Pi-Meetup/)
-  - ~~Website:~~ 
+  - Event hub: [Meetup](https://www.meetup.com/OKC-OSH/)
+  - ~~Website:~~
   - Social media:
     - Facebook:
       - ~~Group~~
@@ -16,7 +16,7 @@ Other Code of Conduct(s): N/A
     - ~~Google group~~
     - ~~LinkedIn group~~
     - ~~Tumblr~~
-    - [Twitter](https://twitter.com/okcrpi)
+    - [Twitter](https://twitter.com/okcosh)
     - Youtube:
       - ~~Account~~
       - ~~Channel~~


### PR DESCRIPTION
Renamed OKC-Raspberry-Pi folder to OKC-Open-Source-Hardware; updated Meetup and Twitter links for group name change.